### PR TITLE
Update Install-ChocoBinaries.ps1

### DIFF
--- a/src/private/Install-ChocoBinaries.ps1
+++ b/src/private/Install-ChocoBinaries.ps1
@@ -25,6 +25,7 @@ function Install-ChocoBinaries {
 	# install choco based on https://chocolatey.org/install#before-you-install
 	try {
 		Write-Verbose 'Installing Chocolatey'
+		[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
 		Invoke-WebRequest 'https://chocolatey.org/install.ps1' -UseBasicParsing | Invoke-Expression > $null
 	} catch {
 		ThrowError -ExceptionName 'System.OperationCanceledException' `


### PR DESCRIPTION
Fixes SSL/TLS error when trying to download install.ps1 from https://chocolatey.org. See powershell command listed at https://chocolatey.org/docs/installation#install-from-powershell-v3.